### PR TITLE
Hide posts from main feed

### DIFF
--- a/admin/controllers/post/edit.bit
+++ b/admin/controllers/post/edit.bit
@@ -12,6 +12,7 @@
 						'content'=>'',
 						'description'=>'',
 						'allow_comments'=>0,
+						'hide_frontpage'=>0,
 						'slug'=>''
 		);
 
@@ -57,6 +58,12 @@
 		if( isset($_POST['allow_comments']) && $_POST['allow_comments']=='1' )
 		{
 			$safe['allow_comments'] = 1;
+		}
+				
+		// Hide from front page
+		if( isset($_POST['hide_frontpage']) && $_POST['hide_frontpage']=='1' )
+		{
+			$safe['hide_frontpage'] = 1;
 		}
 
 		// Publish date

--- a/admin/controllers/post/new.bit
+++ b/admin/controllers/post/new.bit
@@ -13,6 +13,7 @@
 						'content'=>'',
 						'description'=>'',
 						'allow_comments'=>0,
+						'hide_frontpage'=>0,
 						'slug'=>''
 		);
 
@@ -62,6 +63,12 @@
 		if( isset($_POST['allow_comments']) && $_POST['allow_comments']=='1' )
 		{
 			$safe['allow_comments'] = 1;
+		}
+		
+		// Hide from front page
+		if( isset($_POST['hide_frontpage']) && $_POST['hide_frontpage']=='1' )
+		{
+			$safe['hide_frontpage'] = 1;
 		}
 
 		// Add new post

--- a/admin/kernel/db/db_posts.class.php
+++ b/admin/kernel/db/db_posts.class.php
@@ -86,6 +86,7 @@ class DB_POSTS {
 			$new_obj->addChild('content',			$args['content']);
 			$new_obj->addChild('description',		$args['description']);
 			$new_obj->addChild('allow_comments',	$args['allow_comments']);
+			$new_obj->addChild('hide_frontpage',	$args['hide_frontpage']);
 			$new_obj->addChild('slug',				$args['slug']);
 
 			$new_obj->addChild('pub_date',			$time_unix);
@@ -149,6 +150,7 @@ class DB_POSTS {
 			$new_obj->setChild('content', 			$args['content']);
 			$new_obj->setChild('description', 		$args['description']);
 			$new_obj->setChild('allow_comments', 	$args['allow_comments']);
+			$new_obj->setChild('hide_frontpage',	$args['hide_frontpage']);
 			$new_obj->setChild('slug',				$args['slug']);
 			$new_obj->setChild('pub_date',			$args['unixstamp']);
 			$new_obj->setChild('mod_date', 			Date::unixstamp());
@@ -230,7 +232,7 @@ class DB_POSTS {
 
 			if($this->files_count > 0)
 			{
-				return( $this->get_list_by($args['page'], $args['amount']) );
+				return( $this->get_list_by($args['page'], $args['amount'], TRUE) );
 			}
 
 			return(array());
@@ -404,6 +406,7 @@ class DB_POSTS {
 			$tmp_array['mod_date_unix']		= (string) $obj_xml->getChild('mod_date');
 
 			$tmp_array['allow_comments']	= (bool) ((int)$obj_xml->getChild('allow_comments'))==1;
+			$tmp_array['hide_frontpage']	= (bool) ((int)$obj_xml->getChild('hide_frontpage'))==1;
 
 			// CONTENT
 			$tmp_array['content'][0] = $content;
@@ -429,7 +432,7 @@ class DB_POSTS {
 			return( $tmp_array );
 		}
 
-		private function get_list_by($page_number, $post_per_page)
+		private function get_list_by($page_number, $post_per_page, $hide_frontpage=FALSE)
 		{
 			$init = (int) $post_per_page * $page_number;
 			$end  = (int) min( ($init + $post_per_page - 1), $this->files_count - 1 );
@@ -442,7 +445,13 @@ class DB_POSTS {
 			{
 				for($init; $init <= $end; $init++)
 				{
-					array_push( $tmp_array, $this->get_items( $this->files[$init] ) );
+					$next = $this->get_items( $this->files[$init] );
+					if ($hide_frontpage && $next['hide_frontpage']) {
+					 if ($end < ($this->files_count-1)) {
+						$end++;} 
+					} else {
+					array_push( $tmp_array, $next);
+					}
 				}
 			}
 

--- a/admin/views/post/edit.bit
+++ b/admin/views/post/edit.bit
@@ -26,6 +26,9 @@
 		// ALLOW COMMENTS
 		include('includes/allow_comments.bit');
 
+		// HIDE ON MAIN BLOG FEED
+		include('includes/hide_frontpage.bit');
+
 		// BUTTONS
 		include('includes/buttons.bit');
 

--- a/admin/views/post/includes/hide_frontpage.bit
+++ b/admin/views/post/includes/hide_frontpage.bit
@@ -1,0 +1,9 @@
+<?php
+	$value = isset($post_edit['hide_frontpage']) ? $post_edit['hide_frontpage'] : false;
+
+	echo Html::div_open( array('class'=>'form_block', 'hidden'=>!$settings['advanced_post_options']) );
+		echo Html::checkbox( array('id'=>'js_hide_frontpage', 'name'=>'hide_frontpage', 'class'=>'float'), $value );
+		echo Html::label( array('class'=>'for_checkbox', 'content'=>$_LANG['HIDE_FRONTPAGE'], 'for'=>'js_hide_frontpage') );
+		echo Html::div( array('class'=>'input_tip', 'content'=>$_LANG['HIDE_POST_ON_FRONT_PAGE']) );
+	echo Html::div_close();
+?>

--- a/admin/views/post/new_quote.bit
+++ b/admin/views/post/new_quote.bit
@@ -13,6 +13,9 @@
 
 		// ALLOW COMMENTS
 		include('includes/allow_comments.bit');
+		
+		// HIDE ON MAIN BLOG FEED
+		include('includes/hide_frontpage.bit');
 
 		// BUTTONS
 		include('includes/buttons.bit');

--- a/admin/views/post/new_simple.bit
+++ b/admin/views/post/new_simple.bit
@@ -22,6 +22,9 @@
 
 		// ALLOW COMMENTS
 		include('includes/allow_comments.bit');
+		
+		// HIDE ON MAIN BLOG FEED
+		include('includes/hide_frontpage.bit');
 
 		// BUTTONS
 		include('includes/buttons.bit');

--- a/admin/views/post/new_video.bit
+++ b/admin/views/post/new_video.bit
@@ -33,6 +33,9 @@
 
 			// ALLOW COMMENTS
 			include('includes/allow_comments.bit');
+			
+			// HIDE ON MAIN BLOG FEED
+			include('includes/hide_frontpage.bit');
 
 			// BUTTONS
 			include('includes/buttons.bit');

--- a/install.php
+++ b/install.php
@@ -254,7 +254,7 @@ Date::set_timezone('UTC');
 		$content .= '<p>'.$_LANG['WELCOME_POST_LINE3'].'  <a target="_blank" href="http://forum.nibbleblog.com">http://forum.nibbleblog.com</a></p>';
 		$content .= '<p>'.$_LANG['WELCOME_POST_LINE4'].'  <a target="_blank" href="http://www.facebook.com/nibbleblog">https://www.facebook.com/nibbleblog</a></p>';
 		$_DB_POST = new DB_POSTS(FILE_XML_POST, null);
-		$_DB_POST->add( array('id_user'=>0, 'id_cat'=>0, 'type'=>'simple', 'description'=>$_LANG['WELCOME_POST_TITLE'], 'title'=>$_LANG['WELCOME_POST_TITLE'], 'content'=>$content, 'allow_comments'=>'1', 'sticky'=>'0', 'slug'=>'welcome-post') );
+		$_DB_POST->add( array('id_user'=>0, 'id_cat'=>0, 'type'=>'simple', 'description'=>$_LANG['WELCOME_POST_TITLE'], 'title'=>$_LANG['WELCOME_POST_TITLE'], 'content'=>$content, 'allow_comments'=>'1', 'hide_frontpage'=>'0', 'sticky'=>'0', 'slug'=>'welcome-post') );
 
 		$installation_complete = true;
 	}

--- a/languages/en_US.bit
+++ b/languages/en_US.bit
@@ -243,5 +243,7 @@ $_LANG['GOOGLE_WEBMASTER_TOOLS'] = 'Google Webmaster tools - Verification code';
 $_LANG['BING_WEBMASTER_TOOLS'] = 'Bing Webmaster tools - Verification code';
 $_LANG['SEO_OPTIONS'] = 'SEO Options';
 $_LANG['SHARE'] = 'Share';
+$_LANG['HIDE_FRONTPAGE'] = 'Hide on front page';
+$_LANG['HIDE_POST_ON_FRONT_PAGE'] = 'Hide this post from the main blog feed';
 
 ?>


### PR DESCRIPTION
This adds the option for a post to be hidden from the uncategorized blog feed.  This defaults to showing all existing posts when the patch is applied, and posts will always be listed in a per category feed.
