### PR TITLE
Redirect user to admin.php if not logged in

### DIFF
--- a/admin/boot/rules/11-admin.bit
+++ b/admin/boot/rules/11-admin.bit
@@ -78,7 +78,13 @@ if(isset($controllers[$url['controller']][$url['action']]))
 			exit('Nibbleblog security error - Obj $Login not found');
 
 		if(!$Login->is_logged())
-			exit('Nibbleblog security error - User not logged');
+		{
+			$login_page=BLOG_URL.'admin.php';
+			header('Refresh: 2;url='.$login_page);
+			echo 'Nibbleblog security error - User not logged<br />';
+			echo 'goto <a href="'.$login_page.'">login</a> page<br />';
+			exit;
+		}
 	}
 
 	$layout['controller'] 	= $dirname.$parameters['controller'].'.bit';
@@ -87,5 +93,3 @@ if(isset($controllers[$url['controller']][$url['action']]))
 	$layout['title'] 		= $parameters['title'];
 	$layout['id_sidebar']	= isset($parameters['id_sidebar'])?$parameters['id_sidebar']:null;
 }
-
-?>


### PR DESCRIPTION
When user is not logged in and tries to access admin page user gets info
about security error. This might confuse user (e.g. after session
expired).
Added link and auto refresh to admin.php